### PR TITLE
adding command line handling, -q and -d options

### DIFF
--- a/docs/invocation.rst
+++ b/docs/invocation.rst
@@ -10,7 +10,16 @@ package or ``./runkmpc`` from within the root of the git repo. It depends on a
 configuration directory (``~/.kmpc``) and a config file
 (``~/.kmpc/config.ini``) that will be automatically created at first run. You
 will need to edit this config file to add the correct values for various
-variables. It does not currently accept any command line variables.
+variables. The following commandline options are accepted, as well as all the
+default Kivy options::
+
+  usage: kmpc [-h] [-q] [-d] [--helpkivy]
+
+  optional arguments:
+  -h, --help   show this help message and exit
+  -q, --quiet  only print errors to console log
+  -d, --debug  print debug messages to console log
+  --helpkivy   Print Kivy's built-in argument list
 
 ***********
 kmpcmanager
@@ -22,5 +31,14 @@ the root of the git repo. The synchost is a computer running at home that has
 all the music and mpd running on it, as well as all the fanart. ``kmpcmanager``
 provides an interface for downloading fanart for all files in mpd, setting up
 an rsync file to sync with, and changing song ratings and copy flags. This also
-depends on the config folder and file.
+depends on the config folder and file. The following commandline options are
+accepted, as well as all the default Kivy options::
+
+  usage: kmpcmanager [-h] [-q] [-d] [--helpkivy]
+
+  optional arguments:
+  -h, --help   show this help message and exit
+  -q, --quiet  only print errors to console log
+  -d, --debug  print debug messages to console log
+  --helpkivy   Print Kivy's built-in argument list
 

--- a/kmpc/command_line.py
+++ b/kmpc/command_line.py
@@ -1,7 +1,39 @@
+import argparse
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-q","--quiet",help="only print errors to console log",action="store_true")
+parser.add_argument("-d","--debug",help="print debug messages to console log",action="store_true")
+parser.add_argument("--helpkivy",help="Print Kivy's built-in argument list",action="store_true")
+
 def main_app():
+    # since kivy has it's own argparsing, it's necessary to do some argv mangling
+    args,unknown = parser.parse_known_args()
+    sys.argv[1:] = unknown
+    # if --helpkivy is passed, print Kivy's argument list
+    if args.helpkivy:
+        sys.argv.append('-h')
+    # if -d/--debug is passed, use Kivy's -d flag
+    if args.debug:
+        sys.argv.append('-d')
+    from kivy.config import Config
+    if args.quiet:
+        Config.set('kivy','log_level','warning')
     from kmpc import kmpcapp
-    kmpcapp.KmpcApp().run()
+    kmpcapp.KmpcApp(args).run()
 
 def manager_app():
+    # since kivy has it's own argparsing, it's necessary to do some argv mangling
+    args,unknown = parser.parse_known_args()
+    sys.argv[1:] = unknown
+    # if --helpkivy is passed, print Kivy's argument list
+    if args.helpkivy:
+        sys.argv.append('-h')
+    # if -d/--debug is passed, use Kivy's -d flag
+    if args.debug:
+        sys.argv.append('-d')
+    from kivy.config import Config
+    if args.quiet:
+        Config.set('kivy','log_level','warning')
     from kmpc import kmpcmanager
-    kmpcmanager.ManagerApp().run()
+    kmpcmanager.ManagerApp(args).run()

--- a/kmpc/kmpcapp.py
+++ b/kmpc/kmpcapp.py
@@ -14,26 +14,12 @@ kivy.require('1.10.0')
 
 #install twisted reactor to interface with mpd
 from kivy.support import install_twisted_reactor
-# this try/catch block is specifically because sphinx docs fail otherwise
-try:
-    install_twisted_reactor()
-except AttributeError:
-    pass
+install_twisted_reactor()
 from twisted.internet import reactor, protocol
 from twisted.internet.defer import inlineCallbacks
 
-# import config and set key values before other imports
-from kivy.config import Config
-# this try/catch block is specifically because sphinx docs fail otherwise
-try:
-    Config.set('kivy','log_level','info') # set this to 'debug' to see more verbose debug messages
-    Config.set('kivy','keyboard_mode','systemanddock')
-    Config.set('graphics','width',800)
-    Config.set('graphics','height',480)
-except AttributeError:
-    pass
-
 # import all the other kivy stuff
+from kivy.config import Config
 from kivy.app import App
 from kivy.logger import Logger
 from kivy.graphics import Color,Rectangle
@@ -532,6 +518,13 @@ class KmpcInterface(TabbedPanel):
 
 class KmpcApp(App):
     """The overall app class, builds the main interface widget."""
+
+    def __init__(self,args):
+        """Override kivy config values with necessary ones."""
+        Config.set('kivy','keyboard_mode','systemanddock')
+        Config.set('graphics','width',800)
+        Config.set('graphics','height',480)
+        super(self.__class__,self).__init__()
 
     def build(self):
         """Instantiates KmpcInterface."""

--- a/kmpc/kmpcmanager.py
+++ b/kmpc/kmpcmanager.py
@@ -11,7 +11,6 @@ import json
 import subprocess
 import tempfile
 import shutil
-import ConfigParser
 from pkg_resources import resource_filename
 
 # make sure we are on an updated version of kivy
@@ -20,25 +19,11 @@ kivy.require('1.10.0')
 
 #install twisted reactor to interface with mpd
 from kivy.support import install_twisted_reactor
-# this try/catch block is specifically because sphinx docs fail otherwise
-try:
-    install_twisted_reactor()
-except AttributeError:
-    pass
+install_twisted_reactor()
 from twisted.internet import reactor, protocol, task, defer, threads
 
-# import config and set key values before other imports
-from kivy.config import Config
-# this try/catch block is specifically because sphinx docs fail otherwise
-try:
-    Config.set('kivy','log_level','info') # set this to 'debug' to see more verbose debug messages
-    Config.set('graphics','width',1280)
-    Config.set('graphics','height',720)
-    Config.set('kivy','keyboard_mode','system')
-except AttributeError:
-    pass
-
 # import all the other kivy stuff
+from kivy.config import Config
 from kivy.app import App
 from kivy.support import install_twisted_reactor
 from kivy.config import Config
@@ -332,6 +317,13 @@ class ManagerInterface(TabbedPanel):
 
 
 class ManagerApp(App):
+
+    def __init__(self,args):
+        Config.set('graphics','width',1280)
+        Config.set('graphics','height',720)
+        Config.set('kivy','keyboard_mode','system')
+        super(self.__class__,self).__init__()
+
     def build(self):
         config=Helpers.loadconfigfile()
         # setup some variables that interface.kv will use


### PR DESCRIPTION
Since Kivy tries to handle commandline args itself, this kind of hacky approach was needed. There may be a better way. Also removed the try/catch blocks around sections that were breaking autodoc on readthedocs.io, since autodoc was removed from documentation. Fixes #11